### PR TITLE
fixed issue with hidden shiny-alert fields in shiny version 0.11.1+

### DIFF
--- a/R/shiny-alert.R
+++ b/R/shiny-alert.R
@@ -13,7 +13,7 @@
 #' @export
 shinyalert <- function(id, click.hide = TRUE, auto.close.after = NULL) {
     tagList(singleton(tags$head(tags$script(src = "shinysky/shinyalert.js"))), 
-        HTML(paste0("<div id=\"", id, "\" class=\"shinyalert alert hide fade\"  data-alert=\"alert\" click-hide=\"",as.character(click.hide),"\" data-auto-close-after ='",auto.close.after,"'></div>")))
+        HTML(paste0("<div id=\"", id, "\" class=\"shinyalert alert fade\" data-alert=\"alert\" click-hide=\"",as.character(click.hide),"\" data-auto-close-after ='",auto.close.after,"'></div>")))
 }
 
 #' showshinyalert


### PR DESCRIPTION
Due to the switch to bootstrap 3, the shiny-alerts were not visible anymore (hidden by default). I removed the "hide" attribute to circumvent the problem.