### PR TITLE
Fixed select2Input: choices pushed from server are not shown in the list

### DIFF
--- a/inst/www/select2Input.js
+++ b/inst/www/select2Input.js
@@ -23,13 +23,17 @@ Shiny.inputBindings.register(select2InputBinding);
 
 // custom handler
 Shiny.addCustomMessageHandler("updateShinySkySelect2", function(data) {
+  
   var choices = data.choices
+  var id = data.id
+  $("#" + id)
+    .select2({width:'resolve',tags:choices})
   if (typeof data.selected === "string") {
     var selected = [data.selected]
   } else {
     var selected = data.selected
   }
-  var id = data.id
+  
   var label = data.label //not used yet
   var el = $("#" + id).select2("val", selected)
 })


### PR DESCRIPTION
Assume this code is executed in the server.R

```
updateSelect2Input(session, "select2Input1", choices = c("d", "e", "f"), selected = c("f", 
            "d"), label = "hello")
```

Expected behavior is to have the list of choices in the select dropdown being populated with the "d", "e", "f" items. So that when "d" key is pressed, it will show up as a found item of the list. This never happens, because choices pushed from the server side are ignored.

The issue is reproducible in shinysky::run.shinysky.example() as well 
